### PR TITLE
krn-src: use lsb_release to autodetect DIST

### DIFF
--- a/bb-get-rcn-kernel-source.sh
+++ b/bb-get-rcn-kernel-source.sh
@@ -27,8 +27,17 @@
 # Debian.
 #
 
-DIST="raring-armhf"
+#lsb_release: is not installed by default when using debian's debootstrap script.
+has_lsb_release=$(which lsb_release 2>/dev/null)
+if [ "${has_lsb_release}" ] ; then
+	release=$(lsb_release -cs)
+	dpkg_arch=$(dpkg --print-architecture)
+	DIST="${release}-${dpkg_arch}"
+fi
 
+if [ ! "${DIST}" ] ; then
+	DIST="raring-armhf"
+fi
 
 BASE_URL="http://rcn-ee.net/deb"
 OFFICIAL_KERNEL_BASE_URL="https://www.kernel.org/pub/linux/kernel"


### PR DESCRIPTION
Here's a nice trick you can do instead of editing DIST, but lsb_release needs to be installed.. This is fine in my images, but using just Debian's debootstrap, neither wheezy/jessie has it installed by default...

Regards,

Signed-off-by: Robert Nelson robertcnelson@gmail.com
