### PR TITLE
bb-get-rcn-kernel-source.sh: kernel.org .0 releases do not have the .0 i...

### DIFF
--- a/bb-get-rcn-kernel-source.sh
+++ b/bb-get-rcn-kernel-source.sh
@@ -34,7 +34,7 @@ BASE_URL="http://rcn-ee.net/deb"
 OFFICIAL_KERNEL_BASE_URL="https://www.kernel.org/pub/linux/kernel"
 
 KVER=$(uname -r)
-MAIN_KVER=$(echo ${KVER} | sed -nE 's/^(([0-9]+\.?)+).*/\1/gp')
+MAIN_KVER=$(echo ${KVER} | sed -nE 's/^(([0-9]+\.?)+).*/\1/gp' | sed 's/.0//g')
 
 DDIR=$(mktemp -d)
 


### PR DESCRIPTION
...n tarball

See: https://groups.google.com/d/msg/beagleboard/F0oP9eoPPVM/TCoxkJzmCAMJ

Signed-off-by: Robert Nelson <robertcnelson@gmail.com>